### PR TITLE
Adopt animovementtemplate for shared pkgdown config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Suggests:
     knitr,
     testthat (>= 3.0.0)
 Additional_repositories: https://animovement.r-universe.dev
+Config/Needs/website: animovement/animovementtemplate
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,51 +2,11 @@ url: http://animovement.dev/anivis/
 home:
   title: "anivis – An R package for visualizing movement data and diagnostics"
 
-authors:
-  - name: "Mikkel Roald‑Arbøl"
-    href: "https://roald-arboel.com"
-
+# Shared navbar (incl. the animovement dropdown + Zulip), theme, and author
+# details are inherited from animovementtemplate.
 template:
   bootstrap: 5
-  light-switch: true
-
-navbar:
-  structure:
-    left:
-      - reference
-      - news
-    right:
-      - search
-      - animovement
-      - github
-      - zulip
-      - lightswitch
-  components:
-    animovement:
-      icon: fab fa-r-project
-      text: animovement
-      aria-label: animovement
-      menu:
-        - text: anicheck
-          href: https://animovement.dev/anicheck/
-        - text: aniframe
-          href: https://animovement.dev/aniframe/
-        - text: animetric
-          href: https://animovement.dev/animetric/
-        - text: animovement
-          href: https://animovement.dev/animovement/
-        - text: aniprocess
-          href: https://animovement.dev/aniprocess/
-        - text: aniread
-          href: https://animovement.dev/aniread/
-        - text: anispace
-          href: https://animovement.dev/anispace/
-        - text: anivis
-          href: https://animovement.dev/anivis/
-    zulip:
-      icon: fa-comments
-      href: https://animovement.zulipchat.com
-      aria-label: Chat on Zulip
+  package: animovementtemplate
 
 reference:
 - title: "Plotting"


### PR DESCRIPTION
Switches anivis's pkgdown site to inherit its shared configuration from the new
[animovementtemplate](https://github.com/animovement/animovementtemplate)
package, mirroring how easystats packages use `easystatstemplate`.

## What changes
- `_pkgdown.yml` now sets `template: { package: animovementtemplate }` and keeps
  only the package-specific bits (`url`, `home.title`, `reference`).
- The navbar — including the **animovement ecosystem dropdown** and the **Zulip
  link** — plus the theme and author details now come from the template, so they
  live in one place instead of being copied into each package.
- `DESCRIPTION` gains `Config/Needs/website: animovement/animovementtemplate` so
  the pkgdown workflow installs the template from GitHub at build time (no
  CRAN / R-Universe publishing needed — same as easystats).

## Validation
Built locally against the installed template: `check_pkgdown()` passes and the
navbar correctly inherits the dropdown, the Zulip link, and the author href.

## Rollout
anivis is the pilot. Once this looks good on the built site, the same two-line
change (`Config/Needs/website` + `template.package`, minus the inline navbar)
applies mechanically to the other ecosystem packages.