### PR TITLE
Use binary packages in CI, and run R-devel on merges only

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,16 +18,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+        # R-devel has no binaries, so it runs on merges to main, not on PRs.
+        config: >-
+          ${{ github.event_name == 'pull_request'
+          && fromJSON('[
+            {"os": "macos-latest", "r": "release"},
+            {"os": "windows-latest", "r": "release"},
+            {"os": "ubuntu-latest", "r": "release"},
+            {"os": "ubuntu-latest", "r": "oldrel-1"}
+          ]')
+          || fromJSON('[
+            {"os": "macos-latest", "r": "release"},
+            {"os": "windows-latest", "r": "release"},
+            {"os": "ubuntu-latest", "r": "devel", "http-user-agent": "release"},
+            {"os": "ubuntu-latest", "r": "release"},
+            {"os": "ubuntu-latest", "r": "oldrel-1"}
+          ]') }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      # renv's autoloader overrides options(repos), forcing source installs.
+      RENV_CONFIG_AUTOLOADER_ENABLED: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,7 +51,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-          extra-repositories: 'https://roaldarbol.r-universe.dev'
+          extra-repositories: 'https://animovement.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,6 +19,8 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # renv's autoloader overrides options(repos), forcing source installs.
+      RENV_CONFIG_AUTOLOADER_ENABLED: false
     permissions:
       contents: write
     steps:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          extra-repositories: 'https://roaldarbol.r-universe.dev'
+          extra-repositories: 'https://animovement.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # renv's autoloader overrides options(repos), forcing source installs.
+      RENV_CONFIG_AUTOLOADER_ENABLED: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          extra-repositories: 'https://roaldarbol.r-universe.dev'
+          extra-repositories: 'https://animovement.r-universe.dev'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Same change as animovement/animetric#36, where it cut Linux jobs from ~12 minutes to ~2.

## Why CI was slow

`.Rprofile` sources `renv/activate.R` on every R start — including inside the runner — and `activate.R` sets `options(repos)` from the lockfile. That overrides the P3M binary repo (`.../__linux__/noble/latest`) which `use-public-rspm: true` had configured, so pak fell back to the source repo and **compiled every dependency from source, on every run**.

In animetric that was 9m42s of an 11-minute job, against 30s for the check itself.

## Two changes

1. **`RENV_CONFIG_AUTOLOADER_ENABLED: false`** in the workflows that install dependencies. CI resolves dependencies from `DESCRIPTION` via `setup-r-dependencies`, never from the lockfile, so nothing else about the run changes — and packages from `animovement.r-universe.dev` still resolve, since `extra-repositories` is set by `setup-r` independently of renv.

2. **R-devel runs on merges to main, not on pull requests.** P3M publishes binaries per released R version, so a devel job compiles from source regardless — ~13 minutes even with a warm cache. It stays in the matrix for pushes to `main`, so the signal is kept; it just stops gating review.

## Verification

Both matrix branches parse and expand as intended (4 jobs on a pull request, 5 on a push to main), and all three workflow files are valid YAML. The proof is this PR's own checks: there should be no `ubuntu-latest (devel)` job, and the Linux jobs should finish in a couple of minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
