### PR TITLE
Add the shared pr-commands workflow

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,0 +1,15 @@
+# Handles /document and /style comments on pull requests. The workflow lives in
+# animovement/.github so it is maintained in one place; only the trigger is
+# declared here.
+name: pr-commands
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr-commands:
+    uses: animovement/.github/.github/workflows/pr-commands.yml@main
+    permissions:
+      contents: write
+    secrets: inherit


### PR DESCRIPTION
Adds the `/document` and `/style` pull request commands, calling the shared workflow in [`animovement/.github`](https://github.com/animovement/.github/pull/5).

**Merge [animovement/.github#5](https://github.com/animovement/.github/pull/5) first.** This stub fails until the shared workflow is on `main` there.

Commenting `/document` on a pull request re-runs roxygen and pushes the result; `/style` reformats with air and pushes. Both are restricted to comments by a MEMBER or OWNER, so an outside comment cannot cause a push.

This workflow previously existed only in `animovement`, so for the other packages it is a new capability rather than a move. Its `/style` job now runs **air** rather than styler, matching the `format-suggest` workflow that already runs on every pull request here — see the shared PR for why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
