### PR TITLE
fix(check_confidence): put the finest identity on the axis

### DIFF
--- a/R/plot.check_confidence.R
+++ b/R/plot.check_confidence.R
@@ -107,15 +107,28 @@ as_plot_data.check_confidence <- function(x, ..., clip = 0.02) {
   group_cols <- attr(x, "group_cols")
   groups <- attr(x, "groups")
 
-  # The y-axis variable is the grouping column that varies (preferring keypoint
-  # when several do); anything else that varies becomes a facet. With nothing
-  # varying it is a single violin.
+  # The y-axis variable is the finest-grained identity column that varies;
+  # anything else that varies becomes a facet. With nothing varying it is a
+  # single violin.
+  #
+  # `identity_cols` is `variables_what` in declaration order, coarse to fine,
+  # so the finest is the last of them. It matters that this is not simply the
+  # last of `group_cols`: that vector is identity followed by temporal
+  # context, so its last entry may be a session or trial (#21).
   varying <- group_cols[vapply(
     group_cols,
     function(col) length(unique(groups[[col]])) > 1L,
     logical(1)
   )]
-  axis_var <- if ("keypoint" %in% varying) {
+  identity_cols <- attr(x, "identity_cols")
+  varying_identity <- intersect(identity_cols, varying)
+
+  axis_var <- if (length(varying_identity)) {
+    varying_identity[[length(varying_identity)]]
+  } else if (is.null(identity_cols) && "keypoint" %in% varying) {
+    # Objects from an anicheck that predates `identity_cols` carry no roles.
+    # `keypoint` is the finest recognised identity, so it stays the best
+    # guess available for them.
     "keypoint"
   } else if (length(varying)) {
     varying[[1]]

--- a/tests/testthat/helper-check-objects.R
+++ b/tests/testthat/helper-check-objects.R
@@ -37,6 +37,11 @@
     unique(c(what, when))
   }
 
+  aniframe_identity_cols <- function(data) {
+    meta <- aniframe::get_metadata(data)
+    intersect(meta$variables_what, names(data))
+  }
+
   check_na_variable <- function(data, variable) {
     if (is.null(variable) || !length(variable)) {
       cli::cli_abort("{.arg variable} must name at least one column.")
@@ -320,7 +325,12 @@
     out[c(group_cols, "value", "density")]
   }
 
-  new_check_confidence <- function(x, group_cols, groups) {
+  new_check_confidence <- function(
+    x,
+    group_cols,
+    groups,
+    identity_cols = character()
+  ) {
     class(x) <- c(
       "check_confidence",
       "anivis_check_confidence",
@@ -329,6 +339,7 @@
       "data.frame"
     )
     attr(x, "group_cols") <- group_cols
+    attr(x, "identity_cols") <- identity_cols
     attr(x, "groups") <- groups
     x
   }
@@ -352,7 +363,8 @@
     new_check_confidence(
       grid,
       group_cols = group_cols,
-      groups = distribution_summary(df, group_cols, "confidence")
+      groups = distribution_summary(df, group_cols, "confidence"),
+      identity_cols = aniframe_identity_cols(data)
     )
   }
 

--- a/tests/testthat/test-plot.check_confidence.R
+++ b/tests/testthat/test-plot.check_confidence.R
@@ -1,0 +1,61 @@
+# The axis is the finest identity, whatever it is named (#21) ----
+
+confidence_frame <- function(what1, what2, session = FALSE) {
+  set.seed(1)
+  n <- 48
+  d <- data.frame(
+    time = rep(seq_len(n / 4), 4),
+    .a = rep(c("A", "A", "B", "B"), each = n / 4),
+    .b = rep(c("p", "q", "p", "q"), each = n / 4),
+    x = rnorm(n),
+    y = rnorm(n),
+    confidence = runif(n)
+  )
+  if (session) {
+    d$session <- rep(c("s1", "s2"), each = n / 2)
+  }
+  names(d)[names(d) == ".a"] <- what1
+  names(d)[names(d) == ".b"] <- what2
+  aniframe::as_aniframe(d, variables_what = c(what1, what2))
+}
+
+test_that("the axis is the finest identity for recognised names", {
+  pd <- as_plot_data(make_check_confidence(
+    confidence_frame("individual", "keypoint")
+  ))
+
+  expect_equal(attr(pd, "axis_var"), "keypoint")
+})
+
+test_that("the axis is the finest identity for free-form names", {
+  # Previously the fallback took `varying[[1]]` — the *coarsest* varying
+  # column — so a frame declaring identity any other way put the axis and
+  # the facets the wrong way round, silently (#21).
+  pd <- as_plot_data(make_check_confidence(
+    confidence_frame("animal", "bodypart")
+  ))
+
+  expect_equal(attr(pd, "axis_var"), "bodypart")
+  expect_true(
+    "animal" %in% attr(pd, "facet_vars") || is.null(attr(pd, "facet_vars"))
+  )
+})
+
+test_that("temporal context never becomes the axis", {
+  # `group_cols` is identity followed by temporal context, so simply taking
+  # the last varying column would pick `session` here.
+  pd <- as_plot_data(make_check_confidence(
+    confidence_frame("animal", "bodypart", session = TRUE)
+  ))
+
+  expect_equal(attr(pd, "axis_var"), "bodypart")
+})
+
+test_that("a check object without identity_cols still works", {
+  # anicheck gained `identity_cols` for this; objects from before it did not
+  # carry roles, and `keypoint` stays the best guess available for them.
+  chk <- make_check_confidence(confidence_frame("individual", "keypoint"))
+  attr(chk, "identity_cols") <- NULL
+
+  expect_equal(attr(as_plot_data(chk), "axis_var"), "keypoint")
+})


### PR DESCRIPTION
## Description

### What kind of change is this?

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Documentation
- [ ] Maintenance (CI, dependencies, refactoring)
- [ ] Other

### Why is it needed?

`as_plot_data.check_confidence()` chose its axis by looking for a column literally named `keypoint`, falling back to `varying[[1]]`. The comment above it stated the intent — the grouping column that varies, "preferring keypoint when several do", i.e. the **finest** identity. `variables_what` is ordered coarse to fine, so `varying[[1]]` is the **coarsest**: the fallback did the opposite of what it said.

The issue was filed from reading the code and noted it was not yet reproduced. **It reproduces:**

```
                                          before        after
individual + keypoint (recognised)        keypoint      keypoint
animal + bodypart (free-form)             animal   ✘    bodypart ✔
```

The axis and the facets swap. The plot renders without error — just transposed.

### The obvious fix is wrong

The issue proposed taking the last varying entry instead. Right in spirit, wrong in practice: `group_cols` is identity **followed by temporal context**, so on a frame where `session` also varies, the last entry is `session` and the axis becomes a temporal column — worse than the bug.

```
group_cols:  animal  bodypart  session
                     ^^^^^^^^  wanted
                               ^^^^^^^ what "last" would pick
```

anivis cannot tell where the identity prefix ends from `group_cols` alone. animovement/anicheck#22 records `identity_cols` for exactly this; this PR takes the last of the varying ones.

```
animal + bodypart + varying session   ->  axis = bodypart   ✔
```

### Backwards compatibility

Where `identity_cols` is absent — a check object from an earlier anicheck — `keypoint` remains the best guess available, so nothing regresses. Covered by a test that strips the attribute.

## References

Fixes #21. Depends on animovement/anicheck#22 for the attribute; the fallback means this is safe to merge in either order, though the primary path only engages once both are in.

## How has this PR been tested?

Full suite: **275 tests, 0 failures, 0 errors.** Four new tests: recognised names, free-form names, the varying-temporal-column trap, and the no-`identity_cols` fallback.

**The tests deliberately do not call anicheck.** `helper-check-objects.R` vendors anicheck's compute functions precisely so that anicheck is not a dependency of anivis, and its header says so. My first draft used `anicheck::` directly and passed locally only because anicheck happened to be installed — it would have failed `R CMD check` as an undeclared dependency. The tests now use the existing `make_check_*()` builders, and the vendored constructor is updated to attach `identity_cols` so the real path is exercised.

Verified by running the suite with anicheck absent from the library entirely:

```
anicheck attached? FALSE
tests: 275  failed: 0  errors: 0
```

## Is this a breaking change?

Not to any API. Plots of frames whose identity is declared with non-recognised names will change shape — that is the fix. Frames using `keypoint` are unaffected.

## Does this PR require a documentation update?

The `@details` text describing `keypoint` as "the x-axis category" is now the specific case of a general rule; the code comment states the rule. Worth a closer look if you want the prose to match exactly.

## Checklist

- [x] Tests pass locally (`devtools::test()`) — 275 passing
- [x] Tests have been added covering new functionality
- [x] Documentation regenerated if roxygen comments changed (`devtools::document()`)
- [x] Code is formatted with [air](https://posit-dev.github.io/air/)
- [ ] A `NEWS.md` bullet added under `# (development version)` — no `# (development version)` section exists; `DESCRIPTION` is at `0.2.0` with no `.9000`, the post-release step noted in animovement/anivis#23
- [x] I have read and understood every change I am submitting, and tested it myself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
